### PR TITLE
Image Embed Fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,6 @@ pyrightconfig.json
 logs/
 .venv/
 .idea/
+
+# My Files
+test.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ mkdocs
 mkdocs-material
 mkdocstrings
 mkdocstrings-python
+pillow~=11.2.1

--- a/src/cogs/apod.py
+++ b/src/cogs/apod.py
@@ -1,4 +1,5 @@
 import datetime
+import os.path
 import tempfile
 
 import discord
@@ -35,6 +36,10 @@ class APOD(commands.GroupCog, name="apod"):
             nasa_bot_logger.exception(e)
         self.post_daily_image.start()
         self.bot = bot
+        self.temp_dir = tempfile.TemporaryDirectory(prefix="apod-images-cache-")
+        self.temp_file_name = self.temp_dir.name
+        self.apod_image_file = (f"{self.temp_file_name}/"
+                                f"apod-{datetime.date.today()}.jpg")
 
     @app_commands.command(name="daily_image",
                           description="Posts the Astronomy picture of the day.")
@@ -46,6 +51,8 @@ class APOD(commands.GroupCog, name="apod"):
             interaction (discord.Interaction): Represents the interaction
                                                with discord.
         """
+
+        await interaction.response.defer()
         apod = Apod(self.endpoint)
         if apod.is_video():
             try:
@@ -57,14 +64,15 @@ class APOD(commands.GroupCog, name="apod"):
             image_url = apod.url
 
             # Download the image to a temporary file
-            with tempfile.TemporaryFile(prefix="apod_image") as temp_file:
-                apod.download_image(temp_file.name)
-            image_file = discord.File(temp_file.name)
+            if not os.path.exists(self.apod_image_file):
+                apod.download_image(self.apod_image_file)
 
+            filename = os.path.basename(self.apod_image_file)
+            image_file = discord.File(self.apod_image_file, filename=filename)
             try:
-                copyright = apod.copyright
+                apod_copyright = apod.copyright
             except nasa_api_errors.NasaApiDataNotFoundError:
-                copyright = "Copyright: NASA"
+                apod_copyright = "Copyright: NASA"
             color = discord.Color.dark_blue()
             embed = discord.Embed(
                 title="Astronomy Picture of the Day",
@@ -72,13 +80,13 @@ class APOD(commands.GroupCog, name="apod"):
                 color=color,
                 description=image_description
             )
-            embed.set_image(url=f"attachment://{temp_file.name}")
-            embed.set_footer(text=copyright)
+            embed.set_image(url=f"attachment://{filename}")
+            embed.set_footer(text=apod_copyright)
             try:
-                await interaction.response.send_message(embed=embed,
-                                                        file=image_file)
+                await interaction.followup.send(embed=embed, file=image_file)
             except Exception as e:
                 nasa_bot_logger.exception(e)
+
 
     @tasks.loop(time=time)
     async def post_daily_image(self) -> None:
@@ -97,26 +105,52 @@ class APOD(commands.GroupCog, name="apod"):
             image_url = apod.url
 
             # Download the image to a temporary file
-            with tempfile.TemporaryFile() as temp_file:
-                with open(temp_file.name, "rb") as f:
-                    image_file = discord.File(temp_file.name)
-                    try:
-                        copyright = apod.copyright
-                    except nasa_api_errors.NasaApiDataNotFoundError:
-                        copyright = "Copyright: NASA"
-                    color = discord.Color.dark_blue()
-                    embed = discord.Embed(
-                        title="Astronomy Picture of the Day",
-                        url=image_url,
-                        color=color,
-                        description=image_description
-                    )
-                    embed.set_image(url=f"attachment://{temp_file.name}")
-                    embed.set_footer(text=copyright)
-                    try:
-                        await channel.send(embed=embed, file=image_file)
-                    except Exception as e:
-                        nasa_bot_logger.exception(e)
+            if not os.path.exists(self.apod_image_file):
+                apod.download_image(self.apod_image_file)
+
+            filename = os.path.basename(self.apod_image_file)
+            image_file = discord.File(self.apod_image_file, filename=filename)
+            try:
+                apod_copyright = apod.copyright
+            except nasa_api_errors.NasaApiDataNotFoundError:
+                apod_copyright = "Copyright: NASA"
+            color = discord.Color.dark_blue()
+            embed = discord.Embed(
+                title="Astronomy Picture of the Day",
+                url=image_url,
+                color=color,
+                description=image_description
+            )
+            embed.set_image(url=f"attachment://{filename}")
+            embed.set_footer(text=apod_copyright)
+            try:
+                await channel.send(embed=embed, file=image_file)
+
+                # Wipe the cache each day to prevent excessive disk usage.
+                self.clean_up_cache()
+            except Exception as e:
+                nasa_bot_logger.exception(e)
+
+    def clean_up_cache(self) -> None:
+        """
+        Removes all images that are currently in the apod image cache.
+
+        Returns: None
+
+        Raises:
+            FileNotFoundError: If the image file does not exist in the cache.
+
+        Notes:
+            This method is different from a call to the temporary directory's
+            cleanup method as it only removes the images that are currently
+            in the cache, rather than removing the directory itself.
+        """
+        try:
+            for _ in os.listdir(self.temp_dir.name):
+                os.remove(self.apod_image_file)
+        except FileNotFoundError as exception:
+            nasa_bot_logger.exception(f"Error cleaning up cache: {exception}")
+
 
 async def setup(bot: commands.Bot):
     """
@@ -141,3 +175,4 @@ async def setup(bot: commands.Bot):
         await bot.add_cog(APOD(bot), guilds=bot.guilds)
     except Exception as e:
         nasa_bot_logger.exception(e)
+

--- a/src/nasa_api/apod.py
+++ b/src/nasa_api/apod.py
@@ -1,3 +1,5 @@
+import requests
+
 from src.nasa_api.api_request import ApiRequest
 from src.nasa_api.nasa_api_errors import NasaApiDataNotFoundError
 
@@ -177,3 +179,53 @@ class Apod(ApiRequest):
             str: Returns true of the content is an image.
         """
         return self.media_type == "image"
+
+    def download_image(self, file_path: str) -> None:
+        """
+        Downloads the image from the URL to the specified file path.
+
+        Args:
+            file_path (str): The path where the image will be saved.
+
+        Returns: None
+
+        Raises:
+            NasaApiDataNotFoundError: Raised when the request does not return
+            a status code of 200 or if the request does not contain an image.
+        """
+        if self.is_image():
+            with open(file_path, 'wb') as file:
+                response = requests.get(self.url)
+                if response.status_code == 200:
+                    file.write(response.content)
+                else:
+                    raise NasaApiDataNotFoundError(
+                        f"Failed to download image. Status code: "
+                        f"{response.status_code}")
+        else:
+            raise NasaApiDataNotFoundError("Request does not contain an image.")
+
+    def download_hd_image(self, file_path: str) -> None:
+        """
+        Downloads the HD image from the URL to the specified file path.
+
+        Args:
+            file_path (str): The path where the HD image will be saved.
+
+        Returns: None
+
+        Raises:
+            NasaApiDataNotFoundError: Raised when the request does not return
+            a status code of 200 or if the request does not contain an image.
+        """
+        if self.is_image():
+            with open(file_path, 'wb') as file:
+                response = requests.get(self.hdurl)
+                if response.status_code == 200:
+                    file.write(response.content)
+                else:
+                    raise NasaApiDataNotFoundError(
+                        f"Failed to download HD image. Status code: "
+                        f"{response.status_code}")
+        else:
+            raise NasaApiDataNotFoundError("Request does not contain an image.")


### PR DESCRIPTION
Updated bot to fix image embed posting.

New functionality:
- The NASA APOD API wrapper now has new methods that can be used download images in a request to a given file.
- The APOD module of the bot now uses this functionality to attach images to the embed, fixing an issue where URL's were not working to embed the image in discord.
    - Images are downloaded to a temp dir and chached there for the day. That way no new calls need to be made to NASA to get the image for that day.
    - Each day the cache is wiped.